### PR TITLE
BUGFIX: Move middleware before session

### DIFF
--- a/Configuration/Settings.Http.yaml
+++ b/Configuration/Settings.Http.yaml
@@ -4,4 +4,4 @@ Neos:
       middlewares:
         'setAllowCookie':
           middleware: 'Netlogix\Varnish\AllowCookie\Middleware\SetAllowCookieMiddleware'
-          position: 'after securityEntryPoint'
+          position: 'before session'


### PR DESCRIPTION
The Middleware needs to be registered before the `sesssion` Middleware as otherwise the `Set-Cookie` header is not present yet.